### PR TITLE
Strip newlines and carriage returns from exception messages

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -140,8 +140,13 @@ module RSpec
 
         break if exceptions_to_retry.any? && !exception_exists_in?(exceptions_to_retry, example.exception)
 
-        if (attempts != retry_count)
-          retry_reporter_data[example.location] = [attempts, retry_count, example.location, exception_strings(example.exception).join(',')]
+        if attempts != retry_count
+          retry_reporter_data[example.location] = [
+            attempts,
+            retry_count,
+            example.location,
+            inline_exception_strings(example.exception).join(',')
+          ]
 
           if verbose_retry? && display_try_failure_messages?
             try_message = "\n#{ordinalize(attempts)} Try error in #{example.location}:\n#{exception_strings(example.exception).join "\n"}\n"
@@ -194,6 +199,10 @@ module RSpec
       else
         [exception.to_s]
       end
+    end
+
+    def inline_exception_strings(exception)
+      exception_strings(exception).map { |s| s.gsub(/[\n\r\s]+/, ' ').strip }
     end
   end
 end

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -416,7 +416,7 @@ describe RSpec::Retry do
     end
 
     describe 'indeterminate tests' do
-      line_number = __LINE__ + 10
+      line_number = __LINE__ + 18
 
       it 'reports indeterminate tests correctly' do
         group = RSpec.describe 'Indeterminate group', retry: 3 do
@@ -426,8 +426,16 @@ describe RSpec::Retry do
             @@fail = false
           end
 
+          let(:error_message) do
+            <<-ERR
+              broken
+              indeterminate
+              spec
+            ERR
+          end
+
           it 'fails or passes' do
-            raise 'broken indeterminate spec' if @@fail
+            raise error_message if @@fail
 
             true
           end


### PR DESCRIPTION
This formatting is undesireable for downstream workflows consuming the log file.