### PR TITLE
Remove travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RSpec::Retry ![Build Status](https://secure.travis-ci.org/NoRedInk/rspec-retry.svg?branch=master)
+# RSpec::Retry
 
 RSpec::Retry adds a ``:retry`` option for intermittently failing rspec examples.
 If an example has the ``:retry`` option, rspec will retry the example the


### PR DESCRIPTION
🤏  change – removing the badge for now as this was still linking to the original repo and had no relation to ours