### PR TITLE
Write json to flakey spec log

### DIFF
--- a/lib/rspec/flakey_spec.rb
+++ b/lib/rspec/flakey_spec.rb
@@ -16,12 +16,8 @@ module RSpec
       @messages = RetryMessage.new(@example).exception_strings
     end
 
-    def to_h
+    def as_json
       { attempts: @attempts, retry_count: @retry_count, location: @example.location, messages: messages }
-    end
-
-    def to_json(_)
-      to_h.to_json
     end
   end
 end

--- a/lib/rspec/flakey_spec.rb
+++ b/lib/rspec/flakey_spec.rb
@@ -4,18 +4,20 @@ require 'json'
 
 module RSpec
   ##
-  # An instance of an indeterminate spec.
+  # RSpec::FlakeySpec - An instance of an indeterminate spec.
   #
   class FlakeySpec
-    def initialize(attempts, retry_count, location, messages)
+    attr_reader :messages
+
+    def initialize(example, attempts, retry_count)
+      @example = example
       @attempts = attempts
       @retry_count = retry_count
-      @location = location
-      @messages = messages
+      @messages = RetryMessage.new(@example).exception_strings
     end
 
     def to_h
-      { attempts: @attempts, retry_count: @retry_count, location: @location, messages: @messages }
+      { attempts: @attempts, retry_count: @retry_count, location: @example.location, messages: messages }
     end
 
     def to_json(_)

--- a/lib/rspec/flakey_spec.rb
+++ b/lib/rspec/flakey_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module RSpec
+  ##
+  # An instance of an indeterminate spec.
+  #
+  class FlakeySpec
+    def initialize(attempts, retry_count, location, messages)
+      @attempts = attempts
+      @retry_count = retry_count
+      @location = location
+      @messages = messages
+    end
+
+    def to_h
+      { attempts: @attempts, retry_count: @retry_count, location: @location, messages: @messages }
+    end
+
+    def to_json(_)
+      to_h.to_json
+    end
+  end
+end

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -3,11 +3,14 @@
 require 'rspec/core'
 require 'rspec/retry_configuration'
 require 'rspec/retry_message'
+require 'rspec/flakey_spec'
 require 'rspec/retry/version'
 require 'rspec_ext/rspec_ext'
 
 module RSpec
+  ##
   # RSpec::Retry - retry failed examples
+  #
   class Retry
     attr_reader :context, :procsy, :retry_reporter_data
 
@@ -15,7 +18,7 @@ module RSpec
       @procsy = procsy
       @procsy.metadata.merge!(opts)
       current_example.attempts ||= 0
-      @retry_reporter_data = {}
+      @retry_reporter_data = []
     end
 
     def current_example
@@ -61,7 +64,7 @@ module RSpec
         perform_after_retry_tasks(example)
       end
 
-      report_on_flakey_examples if config.retry_reporter && attempts < retry_count
+      report_on_flakey_examples if retry_reporter_data.any? && attempts < retry_count
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
@@ -80,15 +83,6 @@ module RSpec
       list.any? { |exception_klass| exception.is_a?(exception_klass) || exception_klass === exception }
     end
     # rubocop:enable Style/CaseEquality
-
-    def retry_reporter_item(example)
-      [
-        attempts,
-        retry_count,
-        example.location,
-        RetryMessage.new(example).inline_exception_strings.join(',')
-      ]
-    end
 
     def skip_example?(example)
       attempts_gte_retry_count? || exception_should_hard_fail?(example.exception) ||
@@ -121,9 +115,9 @@ module RSpec
     end
 
     def report_on_flakey_examples
-      retry_reporter_data.each_value { |ary| config.retry_reporter&.message(ary.join(',')) }
+      config.retry_reporter&.message(retry_reporter_data.to_json)
 
-      @retry_reporter_data = {}
+      @retry_reporter_data = []
     end
 
     def report_repeat_attempt(example)
@@ -136,11 +130,7 @@ module RSpec
     end
 
     def handle_indeterminate_failures(example)
-      retry_reporter_data[example.location] = retry_reporter_item(example)
-
-      return unless config.verbose_retry? && config.display_try_failure_messages?
-
-      config.reporter.message(RetryMessage.new(example).try_message(attempts))
+      retry_reporter_data << FlakeySpec.new(example, attempts, retry_count)
     end
 
     def perform_after_retry_tasks(example)

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -130,7 +130,7 @@ module RSpec
     end
 
     def handle_indeterminate_failures(example)
-      retry_reporter_data << FlakeySpec.new(example, attempts, retry_count)
+      retry_reporter_data << FlakeySpec.new(example, attempts, retry_count).as_json
     end
 
     def perform_after_retry_tasks(example)

--- a/lib/rspec/retry_message.rb
+++ b/lib/rspec/retry_message.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module RSpec
+  ##
+  # RSpec::RetryMessage - Handles exception messaging for retried Rspec examples
+  #
   class RetryMessage
     attr_reader :example, :exception
 

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -377,79 +377,49 @@ describe RSpec::Retry do
     end
   end
 
-  describe 'output in verbose mode' do
-    line_1 = __LINE__ + 8
-    line_2 = __LINE__ + 11
-    let(:group) do
-      RSpec.describe 'ExampleGroup', retry: 2 do
+  describe 'indeterminate tests' do
+    # rubocop:disable Style/ClassVars
+    let!(:group) do
+      RSpec.describe 'Indeterminate group', retry: 3 do
+        @@fail = true
+
         after do
-          raise 'broken after hook'
+          @@fail = false
         end
 
-        it 'passes' do
+        let(:error_message) do
+          <<-ERR
+            broken
+            indeterminate
+            spec
+          ERR
+        end
+
+        it 'fails or passes' do
+          raise error_message if @@fail
+
           true
         end
-
-        it 'fails' do
-          raise 'broken spec'
-        end
       end
     end
+    # rubocop:enable Style/ClassVars
 
-    it 'outputs failures correctly' do
-      RSpec.configuration.output_stream = output = StringIO.new
-      RSpec.configuration.verbose_retry = true
-      RSpec.configuration.display_try_failure_messages = true
-      expect do
-        group.run RSpec.configuration.reporter
-      end.to change { output.string }.to a_string_including <<-STRING.gsub(/^\s+\| ?/, '')
-        | 1st Try error in ./spec/lib/rspec/retry_spec.rb:#{line_1}:
-        | broken after hook
-        |
-        | RSpec::Retry: 2nd try ./spec/lib/rspec/retry_spec.rb:#{line_1}
-        | F
-        | 1st Try error in ./spec/lib/rspec/retry_spec.rb:#{line_2}:
-        | broken spec
-        | broken after hook
-        |
-        | RSpec::Retry: 2nd try ./spec/lib/rspec/retry_spec.rb:#{line_2}
-      STRING
-    end
+    it 'reports indeterminate tests correctly' do
+      retry_output = StringIO.new
+      reporter = RSpec::Core::Reporter.new(RSpec.configuration)
+      reporter.register_listener(RSpec::Core::Formatters::BaseTextFormatter.new(retry_output), 'message')
+      RSpec.configuration.retry_reporter = reporter
 
-    describe 'indeterminate tests' do
-      line_number = __LINE__ + 18
+      group.run RSpec.configuration.retry_reporter
 
-      it 'reports indeterminate tests correctly' do
-        group = RSpec.describe 'Indeterminate group', retry: 3 do
-          @@fail = true
+      parsed_json = JSON.parse(retry_output.string)
+      expect(parsed_json.size).to eq(1)
 
-          after do
-            @@fail = false
-          end
-
-          let(:error_message) do
-            <<-ERR
-              broken
-              indeterminate
-              spec
-            ERR
-          end
-
-          it 'fails or passes' do
-            raise error_message if @@fail
-
-            true
-          end
-        end
-
-        retry_output = StringIO.new
-        reporter = RSpec::Core::Reporter.new(RSpec.configuration)
-        reporter.register_listener(RSpec::Core::Formatters::BaseTextFormatter.new(retry_output), 'message')
-        RSpec.configuration.retry_reporter = reporter
-        expect do
-          group.run RSpec.configuration.retry_reporter
-        end.to change { retry_output.string }.to "1,3,./spec/lib/rspec/retry_spec.rb:#{line_number},broken indeterminate spec\n"
-      end
+      error_hash = parsed_json.first
+      expect(error_hash['attempts']).to eq(1)
+      expect(error_hash['retry_count']).to eq(3)
+      expect(error_hash['location']).to match(%r{^./spec/lib/rspec/retry_spec.rb:\d+$})
+      expect(error_hash['messages'].map { |m| m.gsub(/\s+/, ' ').strip }).to eq(['broken indeterminate spec'])
     end
   end
 end


### PR DESCRIPTION
Some test formatters don't work very well with a CSV-like log file format.
Log indeterminate test reports as JSON.